### PR TITLE
Handle alignment of streams properly

### DIFF
--- a/lib/membrane/mpeg/ts/demuxer.ex
+++ b/lib/membrane/mpeg/ts/demuxer.ex
@@ -219,7 +219,8 @@ defmodule Membrane.MPEG.TS.Demuxer do
               {[stream_format: {pad, get_format(pad, state, true)}],
                %{state | is_last_aligned: Map.put(state.is_last_aligned, pad, true)}}
 
-            next_buffer.metadata.is_aligned == false and (state.is_last_aligned[pad] || false) ->
+            next_buffer.metadata.is_aligned == false and
+                (state.is_last_aligned[pad] == true or state.is_last_aligned[pad] == nil) ->
               {[stream_format: {pad, get_format(pad, state, false)}],
                %{state | is_last_aligned: Map.put(state.is_last_aligned, pad, false)}}
 

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,8 @@ defmodule Membrane.MPEG.TS.MixProject do
       {:membrane_core, ">= 0.11.0"},
       {:membrane_h264_format, "~> 0.6.1"},
       {:membrane_file_plugin, ">= 0.0.0", only: :test},
-      {:kim_mpeg_ts, github: "kim-company/kim_mpeg_ts"}
+      {:kim_mpeg_ts,
+       github: "membraneframework-labs/kim_mpeg_ts", branch: "handle_alignment_indicator"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -25,8 +25,7 @@ defmodule Membrane.MPEG.TS.MixProject do
       {:membrane_core, ">= 0.11.0"},
       {:membrane_h264_format, "~> 0.6.1"},
       {:membrane_file_plugin, ">= 0.0.0", only: :test},
-      {:kim_mpeg_ts,
-       github: "membraneframework-labs/kim_mpeg_ts", branch: "handle_alignment_indicator"}
+      {:kim_mpeg_ts, github: "kim-company/kim_mpeg_ts"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "bunch": {:hex, :bunch, "1.6.0", "4775f8cdf5e801c06beed3913b0bd53fceec9d63380cdcccbda6be125a6cfd54", [:mix], [], "hexpm", "ef4e9abf83f0299d599daed3764d19e8eac5d27a5237e5e4d5e2c129cfeb9a22"},
   "coerce": {:hex, :coerce, "1.0.1", "211c27386315dc2894ac11bc1f413a0e38505d808153367bd5c6e75a4003d096", [:mix], [], "hexpm", "b44a691700f7a1a15b4b7e2ff1fa30bebd669929ac8aa43cffe9e2f8bf051cf1"},
-  "kim_mpeg_ts": {:git, "https://github.com/membraneframework-labs/kim_mpeg_ts.git", "5c1198d6b3f0cfb2b920fdb2f9259b0e4e0be14a", [branch: "handle_alignment_indicator"]},
+  "kim_mpeg_ts": {:git, "https://github.com/kim-company/kim_mpeg_ts.git", "3c1ad3786c0c5d0298efdb566a93a105159e7193", []},
   "kim_q": {:git, "https://github.com/kim-company/kim_q.git", "a9fcd7f5e38bb4b18f39a86cfd58d044eb7242a0", []},
   "membrane_core": {:hex, :membrane_core, "0.12.9", "b80239deacf98f24cfd2e0703b632e92ddded8b989227cd6e724140f433b0aac", [:mix], [{:bunch, "~> 1.6", [hex: :bunch, repo: "hexpm", optional: false]}, {:qex, "~> 0.3", [hex: :qex, repo: "hexpm", optional: false]}, {:ratio, "~> 2.0", [hex: :ratio, repo: "hexpm", optional: false]}, {:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "389b4b22da0e35d5b053ec2fa87bf36882e0ab88f8fb841af895982fb4abe504"},
   "membrane_file_plugin": {:hex, :membrane_file_plugin, "0.15.0", "ddf9535fda82aae5b0688a98de1d02268287ffc8bcc6dba1a85e057d71c522af", [:mix], [{:membrane_core, "~> 0.12.0", [hex: :membrane_core, repo: "hexpm", optional: false]}], "hexpm", "fa2f7219f96c9e815475dc0d8c238c0a5648012917584756eb3eee476f737ce2"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "bunch": {:hex, :bunch, "1.6.0", "4775f8cdf5e801c06beed3913b0bd53fceec9d63380cdcccbda6be125a6cfd54", [:mix], [], "hexpm", "ef4e9abf83f0299d599daed3764d19e8eac5d27a5237e5e4d5e2c129cfeb9a22"},
   "coerce": {:hex, :coerce, "1.0.1", "211c27386315dc2894ac11bc1f413a0e38505d808153367bd5c6e75a4003d096", [:mix], [], "hexpm", "b44a691700f7a1a15b4b7e2ff1fa30bebd669929ac8aa43cffe9e2f8bf051cf1"},
-  "kim_mpeg_ts": {:git, "https://github.com/kim-company/kim_mpeg_ts.git", "7874e3d1b5c4a2ef40f994a93b5db684abea6341", []},
+  "kim_mpeg_ts": {:git, "https://github.com/membraneframework-labs/kim_mpeg_ts.git", "5c1198d6b3f0cfb2b920fdb2f9259b0e4e0be14a", [branch: "handle_alignment_indicator"]},
   "kim_q": {:git, "https://github.com/kim-company/kim_q.git", "a9fcd7f5e38bb4b18f39a86cfd58d044eb7242a0", []},
   "membrane_core": {:hex, :membrane_core, "0.12.9", "b80239deacf98f24cfd2e0703b632e92ddded8b989227cd6e724140f433b0aac", [:mix], [{:bunch, "~> 1.6", [hex: :bunch, repo: "hexpm", optional: false]}, {:qex, "~> 0.3", [hex: :qex, repo: "hexpm", optional: false]}, {:ratio, "~> 2.0", [hex: :ratio, repo: "hexpm", optional: false]}, {:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "389b4b22da0e35d5b053ec2fa87bf36882e0ab88f8fb841af895982fb4abe504"},
   "membrane_file_plugin": {:hex, :membrane_file_plugin, "0.15.0", "ddf9535fda82aae5b0688a98de1d02268287ffc8bcc6dba1a85e057d71c522af", [:mix], [{:membrane_core, "~> 0.12.0", [hex: :membrane_core, repo: "hexpm", optional: false]}], "hexpm", "fa2f7219f96c9e815475dc0d8c238c0a5648012917584756eb3eee476f737ce2"},


### PR DESCRIPTION
This PR:
* sends appropriate stream format (possibly multiple times) based on `is_aligned` value read from the TS packets
