### PR TITLE
Adjust for handling discontinuity

### DIFF
--- a/lib/membrane/mpeg/ts/demuxer.ex
+++ b/lib/membrane/mpeg/ts/demuxer.ex
@@ -43,7 +43,9 @@ defmodule Membrane.MPEG.TS.Demuxer do
      %{
        state
        | is_last_aligned: Map.put(state.is_last_aligned, pad, nil),
-         unsent_buffer_actions: Map.put(state.unsent_buffer_actions, pad, [])
+         unsent_buffer_actions: Map.put(state.unsent_buffer_actions, pad, []),
+         last_chunk_id_per_pad: Map.put(state.last_chunk_id_per_pad, pad, nil),
+         first_chunk_ts_per_pad: Map.put(state.first_chunk_ts_per_pad, pad, nil)
      }}
   end
 
@@ -55,28 +57,47 @@ defmodule Membrane.MPEG.TS.Demuxer do
   end
 
   @impl true
-  def handle_demand(pad, size, :buffers, _ctx, state) do
-    pending = Map.update(state.pending_demand, pad, size, fn old -> old + size end)
-    fulfill_demand(%{state | pending_demand: pending})
+  def handle_demand(_pad, size, :buffers, _ctx, state) do
+    {[demand: {:input, size}], state}
   end
 
   @impl true
-  def handle_process(:input, buffer, _ctx, state) do
-    state
-    |> update_in([:demuxer], &TS.Demuxer.push_buffer(&1, buffer.payload))
-    |> fulfill_demand()
+  def handle_process(:input, buffer, ctx, state) do
+    state = %{state | chunk_id: state.chunk_id + 1}
+    process_buffer(buffer, state, Map.keys(ctx.pads))
   end
 
   @impl true
-  def handle_end_of_stream(:input, _ctx, state) do
+  def handle_end_of_stream(:input, ctx, state) do
     demuxer = TS.Demuxer.end_of_stream(state.demuxer)
-    fulfill_demand(%{state | closed: true, demuxer: demuxer})
+    state = %{state | closed: true, demuxer: demuxer}
+
+    actions =
+      Map.keys(ctx.pads)
+      |> Enum.filter(fn
+        {Membrane.Pad, :output, _id} -> true
+        _other -> false
+      end)
+      |> Enum.map(fn pad_name -> {:end_of_stream, pad_name} end)
+
+    {actions, state}
+    # TODO - eos can be handled not simuntaniously for all pads
+  end
+
+  @impl true
+  def handle_event(:input, %Membrane.Event.Discontinuity{} = discontinuity, _ctx, state) do
+    {[], %{state | discontinuty_duration: discontinuity.duration}}
+  end
+
+  @impl true
+  def handle_event(:input, event, _ctx, state) do
+    {[forward: event], state}
   end
 
   @impl true
   def handle_info(
         :start_stream_filter,
-        _ctx,
+        ctx,
         state = %{pending_demand: demand}
       ) do
     # Remove unfollowed tracks.
@@ -89,12 +110,27 @@ defmodule Membrane.MPEG.TS.Demuxer do
       domain: __MODULE__
     )
 
-    {[], %{state | demuxer: demuxer}}
+    redemand_actions =
+      ctx.pads
+      |> Enum.filter(fn
+        {Membrane.Pad, :output, _id} -> true
+        _other -> false
+      end)
+      |> Enum.map(fn pad -> {:redemand, pad} end)
+
+    {redemand_actions, %{state | demuxer: demuxer}}
   end
 
-  defp fulfill_demand(state = %{state: :waiting_pmt}) do
+  defp process_buffer(buffer, state = %{state: :waiting_pmt}, _pads) do
     # Eventually I would prefer to drop the state differentiation and notify
     # the pipeline each time a different PMT table is parsed.
+    state =
+      update_in(
+        state,
+        [:demuxer],
+        &TS.Demuxer.push_buffer(&1, buffer.payload, buffer.metadata.from, state.chunk_id)
+      )
+
     pmt = state.demuxer.pmt
 
     if pmt != nil do
@@ -108,73 +144,92 @@ defmodule Membrane.MPEG.TS.Demuxer do
     end
   end
 
-  defp fulfill_demand(state = %{state: :online, demuxer: demuxer}) do
+  defp process_buffer(buffer, state = %{state: :online}, pads) do
+    state =
+      update_in(
+        state,
+        [:demuxer],
+        &TS.Demuxer.push_buffer(&1, buffer.payload, buffer.metadata.from, state.chunk_id)
+      )
+
     # Fetch packet buffers for each pad.
     {buf, demuxer} =
-      state.pending_demand
-      |> Enum.map_reduce(demuxer, fn {pad = {_, _, {:stream_id, sid}}, size}, demuxer ->
+      pads
+      |> Enum.filter(fn
+        {Membrane.Pad, :output, _id} -> true
+        _other -> false
+      end)
+      |> Enum.map_reduce(state.demuxer, fn pad = {Membrane.Pad, :output, {:stream_id, sid}},
+                                           demuxer ->
+        size = TS.Demuxer.size(demuxer, sid)
         {packets, demuxer} = TS.Demuxer.take(demuxer, sid, size)
-        left = TS.Demuxer.size(demuxer, sid)
 
-        {{pad, packets, left}, demuxer}
+        {{pad, packets}, demuxer}
       end)
 
-    # Given the buffers obtained for each pad, update their demand.
-    updated_demand =
-      Enum.reduce(buf, state.pending_demand, fn {pad, packets, _}, acc ->
-        Map.update!(acc, pad, fn size -> size - length(packets) end)
-      end)
-
-    # For each pad that could not be fulfilled, generate a demand action. As
-    # soon as we do not know how the source pad is providing data to us (may be
-    # a TS file for each demand for example), there is no strategy here on how
-    # much to request. If the source has been closed and we do not have more
-    # data, it means we're ready to close the pad.
-    demand_or_close_actions =
-      if state.closed do
-        buf
-        |> Enum.filter(fn {_pad, _packets, left} -> left == 0 end)
-        |> Enum.filter(fn {pad, _packets, _} -> Map.has_key?(updated_demand, pad) end)
-        |> Enum.map(fn {pad, _, _} -> {:end_of_stream, pad} end)
-      else
-        [{:demand, Pad.ref(:input)}]
-      end
-
-    # Now we know which pads will received an :end_of_stream action. Remove
-    # them from the pending_demand map to avoid sending messages to these pads
-    # again.
-    updated_demand =
-      demand_or_close_actions
-      |> Enum.filter(fn {action, _} -> action == :end_of_stream end)
-      |> Enum.reduce(state.pending_demand, fn {_, pad}, acc ->
-        Map.delete(acc, pad)
-      end)
-
-    buffer_actions =
+    {buffer_actions, state} =
       buf
-      |> Enum.filter(fn {_pad, packets, _} -> length(packets) > 0 end)
-      |> Enum.map(fn {pad = {Membrane.Pad, _, {:stream_id, sid}}, packets, _} ->
-        {:buffer,
-         {pad,
-          Enum.map(packets, fn x ->
-            %Membrane.Buffer{
-              payload: x.data,
-              pts: parse_pts_or_dts(x.pts),
-              dts: parse_pts_or_dts(x.dts),
-              metadata: %{
-                stream_id: sid,
-                is_aligned: x.is_aligned
-              }
-            }
-          end)}}
+      |> Enum.filter(fn {_pad, packets} -> length(packets) > 0 end)
+      |> Enum.map_reduce(state, fn {pad = {Membrane.Pad, _, {:stream_id, sid}}, packets}, state ->
+        IO.inspect("NEW PAD")
+
+        {buffers, {last_chunk_id, first_chunk_ts}} =
+          Enum.map_reduce(
+            packets,
+            {state.last_chunk_id_per_pad[pad], state.first_chunk_ts_per_pad[pad]},
+            fn x, {last_chunk_id, first_chunk_ts} ->
+              {last_chunk_id, first_chunk_ts} =
+                if last_chunk_id != x.chunk_id do
+                  first_chunk_ts = (x.dts || x.pts) * Membrane.Time.second() / @h264_time_base
+                  {x.chunk_id, first_chunk_ts}
+                else
+                  {last_chunk_id, first_chunk_ts}
+                end
+
+              pts =
+                parse_pts_or_dts(x.pts, first_chunk_ts, Membrane.Time.seconds(Ratio.new(x.from)))
+
+              dts =
+                parse_pts_or_dts(x.dts, first_chunk_ts, Membrane.Time.seconds(Ratio.new(x.from)))
+
+              IO.inspect({dts, x.from, first_chunk_ts, x.chunk_id}, label: :dts)
+              # IO.inspect(x.from, label: :from123)
+              # IO.inspect(x.chunk_id, label: :chunk_id123)
+              # IO.inspect(first_chunk_ts, label: :first_chunk_ts123)
+
+              {%Membrane.Buffer{
+                 payload: x.data,
+                 pts: pts,
+                 dts: dts,
+                 metadata: %{
+                   stream_id: sid,
+                   is_aligned: x.is_aligned
+                 }
+               }, {last_chunk_id, first_chunk_ts}}
+            end
+          )
+
+        state = %{
+          state
+          | last_chunk_id_per_pad: Map.put(state.last_chunk_id_per_pad, pad, last_chunk_id),
+            first_chunk_ts_per_pad: Map.put(state.first_chunk_ts_per_pad, pad, first_chunk_ts)
+        }
+
+        {{:buffer, {pad, buffers}}, state}
       end)
 
     {buffer_actions, state} = maybe_update_stream_format(buffer_actions, state)
+    state = %{state | demuxer: demuxer, discontinuity_duration: nil}
 
-    actions = buffer_actions ++ demand_or_close_actions
-    state = %{state | pending_demand: updated_demand, demuxer: demuxer}
+    redemand_actions =
+      pads
+      |> Enum.filter(fn
+        {Membrane.Pad, :output, _id} -> true
+        _other -> false
+      end)
+      |> Enum.map(fn pad -> {:redemand, pad} end)
 
-    {actions, state}
+    {buffer_actions ++ redemand_actions, state}
   end
 
   defp maybe_update_stream_format(buffer_actions, state) do
@@ -244,11 +299,13 @@ defmodule Membrane.MPEG.TS.Demuxer do
     end
   end
 
-  defp parse_pts_or_dts(nil), do: nil
+  defp parse_pts_or_dts(nil, _initial_offset, _offset), do: nil
 
-  defp parse_pts_or_dts(ts) do
+  defp parse_pts_or_dts(ts, initial_offset, offset) do
     use Ratio
-    (ts * Membrane.Time.second() / @h264_time_base) |> Ratio.trunc()
+
+    (ts * Membrane.Time.second() / @h264_time_base - initial_offset + (offset || 0))
+    |> Ratio.trunc()
   end
 
   defp new_state() do
@@ -258,7 +315,11 @@ defmodule Membrane.MPEG.TS.Demuxer do
       pending_demand: %{},
       closed: false,
       unsent_buffer_actions: %{},
-      is_last_aligned: %{}
+      is_last_aligned: %{},
+      discontinuity_duration: nil,
+      chunk_id: 0,
+      last_chunk_id_per_pad: %{},
+      first_chunk_ts_per_pad: %{}
     }
   end
 end

--- a/lib/membrane/mpeg/ts/demuxer.ex
+++ b/lib/membrane/mpeg/ts/demuxer.ex
@@ -151,8 +151,7 @@ defmodule Membrane.MPEG.TS.Demuxer do
 
     # Fetch packet buffers for each pad.
     {buf, demuxer} =
-      pads
-      |> Enum.filter(fn
+      Enum.filter(pads, fn
         {Membrane.Pad, :output, _id} -> true
         _other -> false
       end)

--- a/lib/membrane/mpeg/ts/demuxer.ex
+++ b/lib/membrane/mpeg/ts/demuxer.ex
@@ -78,7 +78,6 @@ defmodule Membrane.MPEG.TS.Demuxer do
       |> Enum.map(fn pad_name -> {:end_of_stream, pad_name} end)
 
     {actions, state}
-    # TODO - eos can be handled not simuntaniously for all pads
   end
 
   @impl true
@@ -327,7 +326,6 @@ defmodule Membrane.MPEG.TS.Demuxer do
     %{
       state: :waiting_pmt,
       demuxer: TS.Demuxer.new(),
-      pending_demand: %{},
       closed: false,
       unsent_buffer_actions_per_pad: %{},
       is_last_aligned: %{},

--- a/lib/membrane/mpeg/ts/demuxer.ex
+++ b/lib/membrane/mpeg/ts/demuxer.ex
@@ -93,7 +93,12 @@ defmodule Membrane.MPEG.TS.Demuxer do
         state
       ) do
     # Remove unfollowed tracks.
-    followed_stream_ids = Enum.map(ctx.pads, fn {_, _, {:stream_id, sid}} -> sid end)
+    followed_stream_ids =
+      Enum.filter(ctx.pads, fn
+        {Membrane.Pad, :output, _id} -> true
+        _other -> false
+      end)
+      |> Enum.map(fn {_, _, {:stream_id, sid}} -> sid end)
 
     demuxer = %TS.Demuxer{state.demuxer | packet_filter: &(&1 in followed_stream_ids)}
 

--- a/lib/membrane/mpeg/ts/demuxer.ex
+++ b/lib/membrane/mpeg/ts/demuxer.ex
@@ -94,7 +94,8 @@ defmodule Membrane.MPEG.TS.Demuxer do
       ) do
     # Remove unfollowed tracks.
     followed_stream_ids =
-      Enum.filter(ctx.pads, fn
+      Map.keys(ctx.pads)
+      |> Enum.filter(fn
         {Membrane.Pad, :output, _id} -> true
         _other -> false
       end)

--- a/lib/membrane/mpeg/ts/demuxer.ex
+++ b/lib/membrane/mpeg/ts/demuxer.ex
@@ -120,7 +120,11 @@ defmodule Membrane.MPEG.TS.Demuxer do
       update_in(
         state,
         [:demuxer],
-        &TS.Demuxer.push_buffer(&1, buffer.payload, buffer.metadata[:discontinuity] || false)
+        &TS.Demuxer.push_buffer(
+          &1,
+          buffer.payload,
+          Map.get(buffer.metadata, :discontinuity) || false
+        )
       )
 
     pmt = state.demuxer.pmt
@@ -141,7 +145,11 @@ defmodule Membrane.MPEG.TS.Demuxer do
       update_in(
         state,
         [:demuxer],
-        &TS.Demuxer.push_buffer(&1, buffer.payload, buffer.metadata[:discontinuity] || false)
+        &TS.Demuxer.push_buffer(
+          &1,
+          buffer.payload,
+          Map.get(buffer.metadata, :discontinuity) || false
+        )
       )
 
     # Fetch packet buffers for each pad.

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,8 @@ defmodule Membrane.MPEG.TS.MixProject do
       {:membrane_core, ">= 0.11.0"},
       {:membrane_h264_format, "~> 0.6.1"},
       {:membrane_file_plugin, ">= 0.0.0", only: :test},
-      {:kim_mpeg_ts, github: "kim-company/kim_mpeg_ts"}
+      {:kim_mpeg_ts,
+       github: "membraneframework-labs/kim_mpeg_ts", branch: "adjust_for_handling_discontinuity"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Membrane.MPEG.TS.MixProject do
       {:membrane_h264_format, "~> 0.6.1"},
       {:membrane_file_plugin, ">= 0.0.0", only: :test},
       {:kim_mpeg_ts,
-       github: "membraneframework-labs/kim_mpeg_ts", branch: "adjust_for_handling_discontinuity"}
+       github: "kim-company/kim_mpeg_ts"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -25,8 +25,7 @@ defmodule Membrane.MPEG.TS.MixProject do
       {:membrane_core, ">= 0.11.0"},
       {:membrane_h264_format, "~> 0.6.1"},
       {:membrane_file_plugin, ">= 0.0.0", only: :test},
-      {:kim_mpeg_ts,
-       github: "kim-company/kim_mpeg_ts"}
+      {:kim_mpeg_ts, github: "kim-company/kim_mpeg_ts"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "bunch": {:hex, :bunch, "1.6.0", "4775f8cdf5e801c06beed3913b0bd53fceec9d63380cdcccbda6be125a6cfd54", [:mix], [], "hexpm", "ef4e9abf83f0299d599daed3764d19e8eac5d27a5237e5e4d5e2c129cfeb9a22"},
   "coerce": {:hex, :coerce, "1.0.1", "211c27386315dc2894ac11bc1f413a0e38505d808153367bd5c6e75a4003d096", [:mix], [], "hexpm", "b44a691700f7a1a15b4b7e2ff1fa30bebd669929ac8aa43cffe9e2f8bf051cf1"},
-  "kim_mpeg_ts": {:git, "https://github.com/membraneframework-labs/kim_mpeg_ts.git", "764694e00f6d128b9d476ece8dbacb8ecc53d7aa", [branch: "adjust_for_handling_discontinuity"]},
+  "kim_mpeg_ts": {:git, "https://github.com/kim-company/kim_mpeg_ts.git", "3e3b160b95fa4392201d9ba83b24b27537883c17", []},
   "kim_q": {:git, "https://github.com/kim-company/kim_q.git", "a9fcd7f5e38bb4b18f39a86cfd58d044eb7242a0", []},
   "membrane_core": {:hex, :membrane_core, "0.12.9", "b80239deacf98f24cfd2e0703b632e92ddded8b989227cd6e724140f433b0aac", [:mix], [{:bunch, "~> 1.6", [hex: :bunch, repo: "hexpm", optional: false]}, {:qex, "~> 0.3", [hex: :qex, repo: "hexpm", optional: false]}, {:ratio, "~> 2.0", [hex: :ratio, repo: "hexpm", optional: false]}, {:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "389b4b22da0e35d5b053ec2fa87bf36882e0ab88f8fb841af895982fb4abe504"},
   "membrane_file_plugin": {:hex, :membrane_file_plugin, "0.15.0", "ddf9535fda82aae5b0688a98de1d02268287ffc8bcc6dba1a85e057d71c522af", [:mix], [{:membrane_core, "~> 0.12.0", [hex: :membrane_core, repo: "hexpm", optional: false]}], "hexpm", "fa2f7219f96c9e815475dc0d8c238c0a5648012917584756eb3eee476f737ce2"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "bunch": {:hex, :bunch, "1.6.0", "4775f8cdf5e801c06beed3913b0bd53fceec9d63380cdcccbda6be125a6cfd54", [:mix], [], "hexpm", "ef4e9abf83f0299d599daed3764d19e8eac5d27a5237e5e4d5e2c129cfeb9a22"},
   "coerce": {:hex, :coerce, "1.0.1", "211c27386315dc2894ac11bc1f413a0e38505d808153367bd5c6e75a4003d096", [:mix], [], "hexpm", "b44a691700f7a1a15b4b7e2ff1fa30bebd669929ac8aa43cffe9e2f8bf051cf1"},
-  "kim_mpeg_ts": {:git, "https://github.com/kim-company/kim_mpeg_ts.git", "3c1ad3786c0c5d0298efdb566a93a105159e7193", []},
+  "kim_mpeg_ts": {:git, "https://github.com/membraneframework-labs/kim_mpeg_ts.git", "764694e00f6d128b9d476ece8dbacb8ecc53d7aa", [branch: "adjust_for_handling_discontinuity"]},
   "kim_q": {:git, "https://github.com/kim-company/kim_q.git", "a9fcd7f5e38bb4b18f39a86cfd58d044eb7242a0", []},
   "membrane_core": {:hex, :membrane_core, "0.12.9", "b80239deacf98f24cfd2e0703b632e92ddded8b989227cd6e724140f433b0aac", [:mix], [{:bunch, "~> 1.6", [hex: :bunch, repo: "hexpm", optional: false]}, {:qex, "~> 0.3", [hex: :qex, repo: "hexpm", optional: false]}, {:ratio, "~> 2.0", [hex: :ratio, repo: "hexpm", optional: false]}, {:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "389b4b22da0e35d5b053ec2fa87bf36882e0ab88f8fb841af895982fb4abe504"},
   "membrane_file_plugin": {:hex, :membrane_file_plugin, "0.15.0", "ddf9535fda82aae5b0688a98de1d02268287ffc8bcc6dba1a85e057d71c522af", [:mix], [{:membrane_core, "~> 0.12.0", [hex: :membrane_core, repo: "hexpm", optional: false]}], "hexpm", "fa2f7219f96c9e815475dc0d8c238c0a5648012917584756eb3eee476f737ce2"},

--- a/test/membrane/mpeg/ts/discontinuity_handling_test.exs
+++ b/test/membrane/mpeg/ts/discontinuity_handling_test.exs
@@ -1,0 +1,102 @@
+defmodule Membrane.MPEG.TS.DiscontinuityHandlingTest do
+  use ExUnit.Case
+
+  alias Membrane.Buffer
+  alias Membrane.Testing
+  import Membrane.Testing.Assertions
+  require Membrane.Pad, as: Pad
+
+  @input_ts_file "test/fixtures/bundestag/all.ts"
+
+  defmodule TestingSink do
+    use Membrane.Sink
+
+    def_input_pad(:input, accepted_format: _any, flow_control: :auto)
+
+    @impl true
+    def handle_init(_ctx, _opts) do
+      {[], %{fsm_state: :before_discontinuity}}
+    end
+
+    @impl true
+    def handle_event(:input, %Membrane.Event.Discontinuity{}, _ctx, state) do
+      {[], %{state | fsm_state: :after_discontinuity}}
+    end
+
+    @impl true
+    def handle_buffer(
+          :input,
+          %Buffer{metadata: %{discontinuity: false}},
+          _ctx,
+          %{fsm_state: :before_discontinuity} = state
+        ) do
+      {[], state}
+    end
+
+    @impl true
+    def handle_buffer(
+          :input,
+          %Buffer{metadata: %{discontinuity: true}},
+          _ctx,
+          %{fsm_state: :after_discontinuity} = state
+        ) do
+      {[], state}
+    end
+
+    @impl true
+    def handle_buffer(:input, _buffer, _ctx, _state) do
+      raise "Discontinuity event is dysynchronized with the buffers!"
+    end
+
+    @impl true
+    def handle_end_of_stream(:input, _ctx, state) do
+      {[notify_parent: :eos], state}
+    end
+  end
+
+  test "synchronizes events with buffers" do
+    import Membrane.ChildrenSpec
+
+    spec =
+      child(:source, %Testing.Source{
+        output: {:first_ts, &generator/2}
+      })
+      |> child(:demuxer, Membrane.MPEG.TS.Demuxer)
+
+    pid = Testing.Pipeline.start_link_supervised!(spec: spec)
+
+    receive do
+      {Membrane.Testing.Pipeline, _pid,
+       {:handle_child_notification, {{:mpeg_ts_pmt, pmt}, :demuxer}}} ->
+        pmt.streams
+    end
+
+    link =
+      get_child(:demuxer)
+      |> via_out(Pad.ref(:output, {:stream_id, 481}))
+      |> child(:sink, TestingSink)
+
+    Testing.Pipeline.execute_actions(pid, spec: link)
+    assert_pipeline_notified(pid, :sink, :eos)
+    Testing.Pipeline.terminate(pid)
+  end
+
+  defp generator(:first_ts, _size) do
+    payload = File.read!(@input_ts_file)
+
+    {[
+       stream_format: {:output, %Membrane.RemoteStream{}},
+       buffer: {:output, %Buffer{payload: payload, metadata: %{discontinuity: false}}},
+       redemand: :output
+     ], :second_ts}
+  end
+
+  defp generator(:second_ts, _size) do
+    payload = File.read!(@input_ts_file)
+
+    {[
+       buffer: {:output, %Buffer{payload: payload, metadata: %{discontinuity: true}}},
+       end_of_stream: :output
+     ], :finished}
+  end
+end


### PR DESCRIPTION
This PR:
* Changes the architecture of the element so that the membrane_core can take care of buffering. The `handle_demand` now only demands the buffers, while all possible buffers are being output in the `handle_buffer` function. Such a change simplifies the logic and allows for easier synchronization of stream formats and custom events with the buffers flowing in the same stream.
* Sends the `Membrane.Event.Discontinuity` on the output pads before outputting the first buffer after the discontinuity. The occurrence of the discontinuity is determined by the `:discontinuity` field in the metadata of the input buffer. 

That change allows subsequent elements in the pipeline to take care of handling discontinuity in the stream, such as handling a discontinuity in the HLS playlist, indicated with the ext-discontinuity flag.