### PR TITLE
Fix 'negative steps are not supported in Enum.slice/2' warning

### DIFF
--- a/lib/membrane/mpeg/ts/demuxer.ex
+++ b/lib/membrane/mpeg/ts/demuxer.ex
@@ -276,7 +276,7 @@ defmodule Membrane.MPEG.TS.Demuxer do
 
   defp maybe_update_stream_format_per_pad(pad, state, actions) do
     all_actions = state.unsent_buffer_actions_per_pad[pad] ++ actions
-    shifted_actions = Enum.slice(all_actions, 1..-1) ++ [nil]
+    shifted_actions = Enum.slice(all_actions, 1..-1//1) ++ [nil]
 
     Enum.zip(all_actions, shifted_actions)
     |> Enum.flat_map_reduce(state, fn


### PR DESCRIPTION
I get the following warning on Elixir 1.16.2:

```
warning: negative steps are not supported in Enum.slice/2, pass 1..-1//1 instead
  (elixir 1.16.2) lib/enum.ex:2994: Enum.slice/2
  (stdlib 5.2) erl_eval.erl:746: :erl_eval.do_apply/7
  (elixir 1.16.2) src/elixir.erl:378: :elixir.eval_forms/4
  (elixir 1.16.2) lib/module/parallel_checker.ex:112: Module.ParallelChecker.verify/1
  (iex 1.16.2) lib/iex/evaluator.ex:332: IEx.Evaluator.eval_and_inspect/3
  (iex 1.16.2) lib/iex/evaluator.ex:306: IEx.Evaluator.eval_and_inspect_parsed/3
```

So here I changed as the warning says

cc @dmorn 